### PR TITLE
Add support for the --api-token option

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,15 @@ updates.
 
 - Install via `pip install .` (preferable in a virtualenv).
 - Save your Openshift token in a file called `token`, or specify the file using `--token`
+- Optionally specify the Openshift token via `--api-token`
 - run the `ocl` command:
 
 ```
 ocl --api <your openshift api> [-n <project]
+```
+
+or as follows if specifying the token directly via `--api-token`:
+
+```
+ocl --api <your openshift api> --api-token <your openshift api token> [-n <project]
 ```

--- a/oclogs.py
+++ b/oclogs.py
@@ -343,10 +343,11 @@ def disable_color():
 @click.command()
 @click.option("--token", default=os.path.expanduser("~/token"))
 @click.option("--api")
+@click.option("--api-token")
 @click.option("-n", "--namespace")
 @click.option("--color/--no-color", default=True)
 @click.option("--ca-store")
-def main(token, api, namespace, color, ca_store):
+def main(token, api, api_token, namespace, color, ca_store):
 
     if not api:
         print("Please specify valid api hostname using --api")
@@ -357,8 +358,11 @@ def main(token, api, namespace, color, ca_store):
 
     API = f"https://{api}/api/v1"
 
-    with open(token) as fp:
-        token = fp.read().strip()
+    if api_token:
+        token = api_token
+    else:
+        with open(token) as fp:
+            token = fp.read().strip()
 
     headers = {
         "Authorization": f"Bearer {token}",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='oclogs',
-    version='0.1',
+    version='0.2',
     py_modules=['oclogs'],
     install_requires=[
         'Click',


### PR DESCRIPTION

Added support for the --api-token option to give us a way to specify the OpenShift api token directly
via the command line instead of via a file.
